### PR TITLE
Make elements and windows more compact

### DIFF
--- a/dist/scripts/module.js
+++ b/dist/scripts/module.js
@@ -133,8 +133,8 @@ class DisplayActions2e extends Application {
     return foundry.utils.mergeObject(super.defaultOptions, {
       id: "DisplayActions2e",
       template: `modules/${moduleId}/templates/result.hbs`,
-      width: 600,
-      height: 200,
+      width: 260,
+      height: 110,
       resizable: true,
       title: "DisplayActions2e.WindowTitle"
     });

--- a/dist/style.css
+++ b/dist/style.css
@@ -1,54 +1,62 @@
 .symbol {
-  min-width: 10px;
-  max-width: 100px;
-  min-height: 10px;
-  max-height: 100px;
-  border: none;
+    min-width: 10px;
+    max-width: 30px;
+    min-height: 10px;
+    max-height: 30px;
+    border: none;
 }
 
 .symbolClick {
-  opacity: 0.5;
+    opacity: 0.5;
+}
+
+
+.counter {
+    grid-area: "counter";
+    display: flex;
+    height: fit-content;
+    width: fit-content;
+    min-width: 25px;
 }
 
 .input-counter {
-  width: 25px;
-  column-gap: 5px;
+    column-gap: 5px;
+    max-width: 20px;
 }
 
-.counter {
-  grid-area: "counter";
-  display: flex;
-  height: fit-content;
+.actorLink {
+    line-height: 1.1;
+    width: auto
 }
 
 .actions {
-  grid-area: "actions";
+    grid-area: "actions";
 }
 
 .reactions {
-  grid-area: "reactions";
+    grid-area: "reactions";
 }
 
 .flexbox-actions {
-  display: flex;
-  grid-area: "flex-actions";
+    display: flex;
+    grid-area: "flex-actions";
 }
 
 .wrapper {
-  display: grid;
-  grid-gap: 5px;
-  grid-template-areas: "counter" "flexbox-actions";
-  height: fit-content;
+    display: grid;
+    grid-gap: 5px;
+    grid-template-areas: 
+    "counter"
+    "flexbox-actions";
+    height: fit-content;
 }
 
 .main {
-  width: auto;
-  height: auto;
+    width: auto;
+    height: auto;
 }
 
 /*@font-face {
     font-family: 'pf2-actions';
     src: url("/Data/systems/pf2e/fonts/Pathfinder2eActions.ttf");
 }*/
-
-/*# sourceMappingURL=style.css.map */

--- a/dist/templates/result.hbs
+++ b/dist/templates/result.hbs
@@ -7,7 +7,7 @@
         <label for="num-reaction">Reactions: </label>
         <input class="input-counter" id="count-reaction" name="num-reaction" type="number" value="{{this.numOfReactions}}">
     {{#unless isLinkedToActor}}
-        <button class="actorLink" id="actorLink">Link to selected Actors</button>
+        <button class="actorLink" id="actorLink">Link to Actor</button>
     {{/unless}} 
     {{#if isLinkedToActor}}
         <button class="actorUpdate" id="actorUpdate">Update</button>

--- a/src/styles/module.css
+++ b/src/styles/module.css
@@ -1,8 +1,8 @@
 .symbol {
     min-width: 10px;
-    max-width: 100px;
+    max-width: 30px;
     min-height: 10px;
-    max-height: 100px;
+    max-height: 30px;
     border: none;
 }
 
@@ -10,15 +10,23 @@
     opacity: 0.5;
 }
 
-.input-counter {
-    width: 25px;
-    column-gap: 5px;
-}
 
 .counter {
     grid-area: "counter";
     display: flex;
     height: fit-content;
+    width: fit-content;
+    min-width: 25px;
+}
+
+.input-counter {
+    column-gap: 5px;
+    max-width: 20px;
+}
+
+.actorLink {
+    line-height: 1.1;
+    width: auto
 }
 
 .actions {

--- a/src/templates/result.hbs
+++ b/src/templates/result.hbs
@@ -7,7 +7,7 @@
         <label for="num-reaction">Reactions: </label>
         <input class="input-counter" id="count-reaction" name="num-reaction" type="number" value="{{this.numOfReactions}}">
     {{#unless isLinkedToActor}}
-        <button class="actorLink" id="actorLink">Link to selected Actors</button>
+        <button class="actorLink" id="actorLink">Link to Actor</button>
     {{/unless}} 
     {{#if isLinkedToActor}}
         <button class="actorUpdate" id="actorUpdate">Update</button>

--- a/src/ts/apps/displayActions.ts
+++ b/src/ts/apps/displayActions.ts
@@ -52,8 +52,8 @@ export class DisplayActions2e extends Application {
     return foundry.utils.mergeObject(super.defaultOptions, {
       id: 'DisplayActions2e',
       template: `modules/${moduleId}/templates/result.hbs`,
-      width: 600,
-      height: 200,
+      width: 260,
+      height: 110,
       resizable: true,
       title: 'DisplayActions2e.WindowTitle',
     }) as ApplicationOptions;


### PR DESCRIPTION
Might be worth checking it out first, but these are the settings to make the UI much more compact. Extra options on the title bar can be accessed (like closing the window) by expanding the window. 
By no means a perfect solution, just thought I'd throw it out there if you liked it.

Things can be tweaked pretty easily by referencing the differences. This is the result (using a dark mode theme anyway):

<img width="463" alt="Screenshot 2023-02-01 at 7 11 25 pm" src="https://user-images.githubusercontent.com/28495826/215986898-7b5a0029-a30f-4a48-b1e8-e96ec955611a.png">
