### PR TITLE
update manifest discontinues support for V9

### DIFF
--- a/dist/module.json
+++ b/dist/module.json
@@ -1,21 +1,24 @@
 {
     "$schema": "https://json.schemastore.org/foundryvtt-manifest.json",
     "name": "pf2e-display-actions",
-    "author": {
-        "name": "MoonIsFalling",
-        "Discord": "Thieftain#0744"
-    },
+    "id": "pf2e-display-actions",
+    "authors": [
+        {
+            "name": "Thieftain",
+            "GitHub": "MoonIsFalling",
+            "Discord": "Thieftain#0744"
+        }
+    ],
     "title": "Pf2e Display Actions",
     "description": "A small module to display the pathfinder action economy for convinience.",
-    "version": "1.7.1",
+    "version": "1.8.0",
     "packs": [],
     "system": [
         "pf2e"
     ],
-    "dependencies": [],
     "scripts": [],
     "compatibility": {
-        "minimum": "9",
+        "minimum": "10",
         "verified": "10",
         "maximum": "10"
     },
@@ -33,8 +36,8 @@
         "scripts/module.js"
     ],
     "url": "https://github.com/MoonIsFalling/pf2e-display-actions",
-    "manifest": "https://github.com/MoonIsFalling/pf2e-display-actions/releases/download/1.7.1/module.json",
-    "download": "https://github.com/MoonIsFalling/pf2e-display-actions/releases/download/1.7.1/module.zip",
+    "manifest": "https://github.com/MoonIsFalling/pf2e-display-actions/releases/download/1.8.0/module.json",
+    "download": "https://github.com/MoonIsFalling/pf2e-display-actions/releases/download/1.8.0/module.zip",
     "includes": [
         "./images/**",
         "./languages/**",
@@ -49,5 +52,10 @@
     "bugs": "https://github.com/MoonIsFalling/pf2e-display-actions/issues",
     "flags": {
         "allowBugReporter": true
+    },
+    "relationships": {
+        "system": [
+            "pf2e"
+        ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pf2e-display-actions",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "A small module to display the pathfinder action economy for convinience.",
   "license": "MIT",
   "private": true,

--- a/src/module.json
+++ b/src/module.json
@@ -1,19 +1,22 @@
 {
   "$schema": "https://json.schemastore.org/foundryvtt-manifest.json",
   "name": "pf2e-display-actions",
-  "author": {
-    "name": "MoonIsFalling",
-    "Discord": "Thieftain#0744"
-  },
+  "id": "pf2e-display-actions",
+  "authors": [
+    {
+      "name": "Thieftain",
+      "GitHub": "MoonIsFalling",
+      "Discord": "Thieftain#0744"
+    }
+  ],
   "title": "Pf2e Display Actions",
   "description": "A small module to display the pathfinder action economy for convinience.",
   "version": "1.5.0",
   "packs": [],
   "system": ["pf2e"],
-  "dependencies": [],
   "scripts": [],
   "compatibility": {
-    "minimum": "9",
+    "minimum": "10",
     "verified": "10",
     "maximum": "10"
   },
@@ -43,5 +46,8 @@
   "bugs": "https://github.com/MoonIsFalling/pf2e-display-actions/issues",
   "flags": {
     "allowBugReporter": true
+  },
+  "relationships": {
+    "system": ["pf2e"]
   }
 }


### PR DESCRIPTION
updating the manifest for V10 this may break V9 support. Thus V9 is discontinues.

V9 is still supported until v1.7.1