### PR TITLE
Improve input alignment

### DIFF
--- a/src/styles/module.css
+++ b/src/styles/module.css
@@ -20,6 +20,8 @@
 }
 
 .counter {
+    align-items: center;
+    gap: 5px;
     grid-area: "counter";
     display: flex;
     height: fit-content;


### PR DESCRIPTION
I did some small changes to better align the input fields with their labels.

<img width="390" height="190" alt="Bildschirmfoto vom 2025-10-16 21-06-57" src="https://github.com/user-attachments/assets/5a2fcd9c-cbf3-43b0-a8ce-50669bf57cd9" />

`dist` was not rebuild.